### PR TITLE
AtomicBuffer opaque methods

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/AtomicBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/AtomicBuffer.java
@@ -149,6 +149,34 @@ public interface AtomicBuffer extends MutableDirectBuffer
     long addLongOrdered(int index, long increment);
 
     /**
+     * Atomically put a value to a given index with opaque semantics.
+     *
+     * @param index in bytes for where to put.
+     * @param value for at a given index.
+     */
+    void putLongOpaque(int index, long value);
+
+    /**
+     * Atomically get a value to a given index with opaque semantics.
+     *
+     * @param index in bytes for where to put.
+     * @return the value for at a given index.
+     */
+    long getLongOpaque(int index);
+
+    /**
+     * Adds a value to a given index with opaque semantics. The read and write
+     * will be atomic, but the combination is not atomic. So don't use this
+     * method concurrently because you can run into lost updates due to
+     * a race-condition.
+     *
+     * @param index in bytes for where to put.
+     * @param increment by which the value at the index will be adjusted.
+     * @return the previous value at the index.
+     */
+    long addLongOpaque(int index, long increment);
+
+    /**
      * Atomically adds a value to a given index with ordered store semantics. Use a negative increment to decrement.
      * <p>
      * The load has no ordering semantics. The store has release semantics.
@@ -269,6 +297,34 @@ public interface AtomicBuffer extends MutableDirectBuffer
      * @since 2.1.0
      */
     int addIntRelease(int index, int increment);
+
+    /**
+     * Atomically put a value to a given index with opaque semantics.
+     *
+     * @param index in bytes for where to put.
+     * @param value for at a given index.
+     */
+    void putIntOpaque(int index, int value);
+
+    /**
+     * Atomically get a value to a given index with opaque semantics.
+     *
+     * @param index in bytes for where to put.
+     * @return the value for at a given index.
+     */
+    int getIntOpaque(int index);
+
+    /**
+     * Adds a value to a given index with opaque semantics. The read and write
+     * will be atomic, but the combination is not atomic. So don't use this
+     * method concurrently because you can run into lost updates due to
+     * a race-condition.
+     *
+     * @param index in bytes for where to put.
+     * @param increment by which the value at the index will be adjusted.
+     * @return the previous value at the index.
+     */
+    int addIntOpaque(int index, int increment);
 
     /**
      * Atomic compare and set of an int given an expected value.

--- a/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/UnsafeBuffer.java
@@ -456,6 +456,48 @@ public class UnsafeBuffer extends AbstractMutableDirectBuffer implements AtomicB
     /**
      * {@inheritDoc}
      */
+    public void putLongOpaque(final int index, final long value)
+    {
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, SIZE_OF_LONG);
+        }
+
+        UnsafeApi.putLongOpaque(byteArray, addressOffset + index, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long getLongOpaque(final int index)
+    {
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, SIZE_OF_LONG);
+        }
+
+        return UnsafeApi.getLongOpaque(byteArray, addressOffset + index);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public long addLongOpaque(final int index, final long increment)
+    {
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, SIZE_OF_LONG);
+        }
+
+        final long oldValue = UnsafeApi.getLongOpaque(byteArray, addressOffset + index);
+        final long newValue = oldValue + increment;
+        UnsafeApi.putLongOpaque(byteArray, addressOffset + index, newValue);
+        return oldValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public boolean compareAndSetLong(final int index, final long expectedValue, final long updateValue)
     {
         if (SHOULD_BOUNDS_CHECK)
@@ -571,6 +613,49 @@ public class UnsafeBuffer extends AbstractMutableDirectBuffer implements AtomicB
         }
 
         return UnsafeApi.getAndAddIntRelease(byteArray, addressOffset + index, increment);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public void putIntOpaque(final int index, final int value)
+    {
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, SIZE_OF_LONG);
+        }
+
+        UnsafeApi.putIntOpaque(byteArray, addressOffset + index, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int getIntOpaque(final int index)
+    {
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, SIZE_OF_LONG);
+        }
+
+        return UnsafeApi.getIntOpaque(byteArray, addressOffset + index);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int addIntOpaque(final int index, final int increment)
+    {
+        if (SHOULD_BOUNDS_CHECK)
+        {
+            boundsCheck0(index, SIZE_OF_LONG);
+        }
+
+        final int oldValue = UnsafeApi.getIntOpaque(byteArray, addressOffset + index);
+        final int newValue = oldValue + increment;
+        UnsafeApi.putIntOpaque(byteArray, addressOffset + index, newValue);
+        return oldValue;
     }
 
     /**


### PR DESCRIPTION
Added opaque operations to AtomicBuffer for int/long. An opaque loads/stores provides atomicity and visibility, but it doesn't provide any ordering guarantees beyond coherence. So it doesn't order loads/stores to different addresses (doesn't provide consistency), only to its own address (coherence). Opaque is very much like a C-style volatile and can be used in the same situation as the C++ memory_order_relaxed.

For more info see:

https://gee.cs.oswego.edu/dl/html/j9mm.html

Opaque operations are great for performance counters or progress indicators and provide the least amount of overhead on the CPU (all modern CPUs are coherent); especially ISA's with a weak memory model like ARM or RISC-V. It provides less value on the X86 since every store is a release store and every load is an acquire load.

Opaque is great for single writer multiple reader scenario's.

Idea:
Instead of using the naming 'opaque', the name 'relaxed' could be an idea. With relaxed coming from memory_order_relaxed.