### PR TITLE
Position acquire/release methods

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/status/AtomicLongPosition.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/AtomicLongPosition.java
@@ -88,6 +88,12 @@ public class AtomicLongPosition extends Position
         return value.get();
     }
 
+    @Override
+    public long getAcquire()
+    {
+        return value.getAcquire();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -101,7 +107,15 @@ public class AtomicLongPosition extends Position
      */
     public void setOrdered(final long value)
     {
-        this.value.lazySet(value);
+        setRelease(value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setRelease(final long value)
+    {
+        this.value.setRelease(value);
     }
 
     /**
@@ -117,7 +131,7 @@ public class AtomicLongPosition extends Position
      */
     public boolean proposeMax(final long proposedValue)
     {
-        return proposeMaxOrdered(proposedValue);
+        return proposeMaxRelease(proposedValue);
     }
 
     /**
@@ -125,11 +139,19 @@ public class AtomicLongPosition extends Position
      */
     public boolean proposeMaxOrdered(final long proposedValue)
     {
+        return proposeMaxRelease(proposedValue);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean proposeMaxRelease(final long proposedValue)
+    {
         boolean updated = false;
 
-        if (get() < proposedValue)
+        if (value.get() < proposedValue)
         {
-            setOrdered(proposedValue);
+            value.setRelease(proposedValue);
             updated = true;
         }
 

--- a/agrona/src/main/java/org/agrona/concurrent/status/Position.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/Position.java
@@ -37,7 +37,7 @@ public abstract class Position extends ReadablePosition
     public abstract boolean isClosed();
 
     /**
-     * Get the current position of a component without memory ordering semantics.
+     * Get the current position of a component with plain memory ordering semantics.
      *
      * @return the current position of a component
      */
@@ -52,10 +52,19 @@ public abstract class Position extends ReadablePosition
 
     /**
      * Sets the current position of the component with ordered memory semantics.
+     * <p>
+     * This method is identical to {@link #setRelease(long)} and that method should be used instead.
      *
      * @param value the current position of the component.
      */
     public abstract void setOrdered(long value);
+
+    /**
+     * Sets the current position of the component with release memory semantics.
+     *
+     * @param value the current position of the component.
+     */
+    public abstract void setRelease(long value);
 
     /**
      * Sets the current position of the component with volatile memory semantics.
@@ -74,9 +83,20 @@ public abstract class Position extends ReadablePosition
 
     /**
      * Set the position to the new proposedValue if greater than the current value with memory ordering semantics.
+     * <p>
+     * This method is identical to {@link #proposeMaxRelease(long)} and that method should be preferred instead.
      *
      * @param proposedValue for the new max.
      * @return true if a new max as been set otherwise false.
      */
     public abstract boolean proposeMaxOrdered(long proposedValue);
+
+    /**
+     * Set the position to the new proposedValue if greater than the current value with release memory ordering
+     * semantics.
+     *
+     * @param proposedValue for the new max.
+     * @return true if a new max as been set otherwise false.
+     */
+    public abstract boolean proposeMaxRelease(long proposedValue);
 }

--- a/agrona/src/main/java/org/agrona/concurrent/status/Position.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/Position.java
@@ -63,6 +63,7 @@ public abstract class Position extends ReadablePosition
      * Sets the current position of the component with release memory semantics.
      *
      * @param value the current position of the component.
+     * @since 2.1.0
      */
     public abstract void setRelease(long value);
 

--- a/agrona/src/main/java/org/agrona/concurrent/status/ReadablePosition.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/ReadablePosition.java
@@ -42,6 +42,13 @@ public abstract class ReadablePosition implements AutoCloseable
     public abstract long getVolatile();
 
     /**
+     * Get the current position of a component with acquire semantics.
+     *
+     * @return the current position of a component.
+     */
+    public abstract long getAcquire();
+
+    /**
      * {@inheritDoc}
      */
     public abstract void close();

--- a/agrona/src/main/java/org/agrona/concurrent/status/ReadablePosition.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/ReadablePosition.java
@@ -45,6 +45,7 @@ public abstract class ReadablePosition implements AutoCloseable
      * Get the current position of a component with acquire semantics.
      *
      * @return the current position of a component.
+     * @since 2.1.0
      */
     public abstract long getAcquire();
 

--- a/agrona/src/main/java/org/agrona/concurrent/status/UnsafeBufferPosition.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/UnsafeBufferPosition.java
@@ -102,6 +102,14 @@ public class UnsafeBufferPosition extends Position
     /**
      * {@inheritDoc}
      */
+    public long getAcquire()
+    {
+        return UnsafeApi.getLongAcquire(byteArray, addressOffset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void set(final long value)
     {
         UnsafeApi.putLong(byteArray, addressOffset, value);
@@ -111,6 +119,14 @@ public class UnsafeBufferPosition extends Position
      * {@inheritDoc}
      */
     public void setOrdered(final long value)
+    {
+        setRelease(value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setRelease(final long value)
     {
         UnsafeApi.putLongRelease(byteArray, addressOffset, value);
     }
@@ -145,6 +161,14 @@ public class UnsafeBufferPosition extends Position
      * {@inheritDoc}
      */
     public boolean proposeMaxOrdered(final long proposedValue)
+    {
+        return proposeMaxRelease(proposedValue);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean proposeMaxRelease(final long proposedValue)
     {
         boolean updated = false;
 

--- a/agrona/src/test/java/org/agrona/concurrent/status/CountersManagerTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/status/CountersManagerTest.java
@@ -329,7 +329,7 @@ class CountersManagerTest
         final Position writer = new UnsafeBufferPosition(valuesBuffer, id);
         final long expectedValue = 0xF_FFFF_FFFFL;
 
-        writer.setOrdered(expectedValue);
+        writer.setRelease(expectedValue);
 
         assertEquals(expectedValue, reader.getVolatile());
     }


### PR DESCRIPTION
For every ordered method, a release method was added. Every ordered method forwards to a release method. So there is a slight performance penalty to pay for the ordered methods.

The ordered methods are from an old naming schema. Since Java 9, the 'release' naming is the used schema.

Also an getAcquire has been added, since release methods typically should be used with an acquire.