### PR TITLE
AtomicCounter plain methods.

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/status/AtomicCounter.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/AtomicCounter.java
@@ -303,6 +303,7 @@ public class AtomicCounter implements AutoCloseable
      * Set the counter value with plain memory semantics.
      *
      * @param value to be set with normal semantics.
+     * @since 2.1.0
      */
     public void setPlain(final long value)
     {

--- a/agrona/src/main/java/org/agrona/concurrent/status/AtomicCounter.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/AtomicCounter.java
@@ -220,7 +220,25 @@ public class AtomicCounter implements AutoCloseable
         final long offset = addressOffset;
         final long currentValue = UnsafeApi.getLong(array, offset);
         UnsafeApi.putLongRelease(array, offset, currentValue + 1);
+        return currentValue;
+    }
 
+    /**
+     * Increment the counter.
+     * <p>
+     * This method is not atomic and this can lead to lost-updates due to race conditions. This load and store
+     * have plain memory semantics.
+     * <p>
+     * The typical use-case for this method is when writer and reader are the same thread.
+     *
+     * @return the previous value of the counter
+     */
+    public long incrementPlain()
+    {
+        final byte[] array = byteArray;
+        final long offset = addressOffset;
+        final long currentValue = UnsafeApi.getLong(array, offset);
+        UnsafeApi.putLong(array, offset, currentValue + 1);
         return currentValue;
     }
 
@@ -271,10 +289,22 @@ public class AtomicCounter implements AutoCloseable
 
     /**
      * Set the counter with normal semantics.
+     * <p>
+     * This method is identical to {@link #setPlain(long)} and that method should be used instead.
      *
      * @param value to be set with normal semantics.
      */
     public void setWeak(final long value)
+    {
+        setPlain(value);
+    }
+
+    /**
+     * Set the counter value with plain memory semantics.
+     *
+     * @param value to be set with normal semantics.
+     */
+    public void setPlain(final long value)
     {
         UnsafeApi.putLong(byteArray, addressOffset, value);
     }
@@ -345,6 +375,17 @@ public class AtomicCounter implements AutoCloseable
      * @return the  value for the counter.
      */
     public long getWeak()
+    {
+        return getPlain();
+    }
+
+    /**
+     * Get the value of the counter using plain memory semantics. This is the same a standard read of a field.
+     *
+     * @return the  value for the counter.
+     * @since 2.1.0
+     */
+    public long getPlain()
     {
         return UnsafeApi.getLong(byteArray, addressOffset);
     }

--- a/agrona/src/main/java/org/agrona/concurrent/status/AtomicCounter.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/AtomicCounter.java
@@ -232,6 +232,7 @@ public class AtomicCounter implements AutoCloseable
      * The typical use-case for this method is when writer and reader are the same thread.
      *
      * @return the previous value of the counter
+     * @since 2.1.0
      */
     public long incrementPlain()
     {
@@ -263,6 +264,27 @@ public class AtomicCounter implements AutoCloseable
         final long offset = addressOffset;
         final long currentValue = UnsafeApi.getLong(array, offset);
         UnsafeApi.putLongRelease(array, offset, currentValue - 1);
+
+        return currentValue;
+    }
+
+    /**
+     * Decrements the counter.
+     * <p>
+     * This method is not atomic and this can lead to lost-updates due to race conditions. This load and store
+     * have plain memory semantics.
+     * <p>
+     * The typical use-case for this method is when writer and reader are the same thread.
+     *
+     * @return the previous value of the counter
+     * @since 2.1.0
+     */
+    public long decrementPlain()
+    {
+        final byte[] array = byteArray;
+        final long offset = addressOffset;
+        final long currentValue = UnsafeApi.getLong(array, offset);
+        UnsafeApi.putLong(array, offset, currentValue - 1);
 
         return currentValue;
     }

--- a/agrona/src/test/java/org/agrona/concurrent/status/AtomicCountersTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/status/AtomicCountersTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona.concurrent.status;
+
+import org.agrona.concurrent.AtomicBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AtomicCountersTest
+{
+
+    @Test
+    public void testPlain()
+    {
+        final AtomicBuffer buffer = new UnsafeBuffer(new byte[8]);
+        final AtomicCounter counter = new AtomicCounter(buffer, 0);
+
+        assertEquals(0, counter.getPlain());
+        counter.incrementPlain();
+        assertEquals(1, counter.getPlain());
+        counter.setPlain(42);
+        assertEquals(42, counter.getPlain());
+    }
+}

--- a/agrona/src/test/java/org/agrona/concurrent/status/AtomicCountersTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/status/AtomicCountersTest.java
@@ -31,9 +31,14 @@ public class AtomicCountersTest
         final AtomicCounter counter = new AtomicCounter(buffer, 0);
 
         assertEquals(0, counter.getPlain());
+
         counter.incrementPlain();
         assertEquals(1, counter.getPlain());
+
         counter.setPlain(42);
         assertEquals(42, counter.getPlain());
+
+        counter.decrementPlain();
+        assertEquals(41, counter.getPlain());
     }
 }


### PR DESCRIPTION
There was already a getWeak. A more standard naming is 'normal' or 'plain'. So a new method getPlain has been added. Also setPlain and 'incrementPlain' have been added.