### PR TITLE
MarkFile timestampRelease method

### DIFF
--- a/agrona/src/main/java/org/agrona/MarkFile.java
+++ b/agrona/src/main/java/org/agrona/MarkFile.java
@@ -284,10 +284,22 @@ public class MarkFile implements AutoCloseable
 
     /**
      * Set timestamp field using an ordered put.
+     * <p>
+     * This method is identical to {@link #timestampRelease(long)} and that method is preferred.
      *
      * @param timestamp to be set.
      */
     public void timestampOrdered(final long timestamp)
+    {
+        timestampRelease(timestamp);
+    }
+
+    /**
+     * Set timestamp field using a release put.
+     *
+     * @param timestamp to be set.
+     */
+    public void timestampRelease(final long timestamp)
     {
         buffer.putLongRelease(timestampFieldOffset, timestamp);
     }


### PR DESCRIPTION
This method is a replacement for the timestampOrdered. The ordered methods use an old naming schema and the release methods use the new naming schema.

There is a slight performance penalty because the timestampOrdered calls the timestampRelease method.