### PR TITLE
AtomicLongPosition plain methods fix.

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/status/AtomicLongPosition.java
+++ b/agrona/src/main/java/org/agrona/concurrent/status/AtomicLongPosition.java
@@ -77,7 +77,7 @@ public class AtomicLongPosition extends Position
      */
     public long get()
     {
-        return value.get();
+        return value.getPlain();
     }
 
     /**
@@ -99,7 +99,7 @@ public class AtomicLongPosition extends Position
      */
     public void set(final long value)
     {
-        this.value.lazySet(value);
+        this.value.setPlain(value);
     }
 
     /**


### PR DESCRIPTION
The methods AtomicLongPosition.get and AtomicLongPosition.set, which have plain semantics according to the documentation, are calling AtomicLong.get/set which have volatile semantics. So they are calling methods that are more thread-safe than needed, leading to a potential performance penalty.

The same methods on the UnsafeBufferPosition, do call the right plain methods.
