### PR TITLE
Fix UnsafeApi arrayBaseOffset

### DIFF
--- a/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
+++ b/agrona-agent/src/test/java/org/agrona/agent/BufferAlignmentAgentTest.java
@@ -40,7 +40,8 @@ class BufferAlignmentAgentTest
     private static final CharSequence TEST_CHAR_SEQUENCE = new StringBuilder("BufferAlignmentTest");
 
     //on 32-bits JVMs, array content is not 8-byte aligned => need to add 4 bytes offset
-    private static final int HEAP_BUFFER_ALIGNMENT_OFFSET = UnsafeApi.arrayBaseOffset(byte[].class) % 8;
+    // todo: ugly
+    private static final int HEAP_BUFFER_ALIGNMENT_OFFSET = (int)(UnsafeApi.arrayBaseOffset(byte[].class) % 8);
 
     @BeforeAll
     static void installAgent()

--- a/agrona/src/main/java/org/agrona/Main.java
+++ b/agrona/src/main/java/org/agrona/Main.java
@@ -16,12 +16,14 @@
 package org.agrona;
 
 /**
- *
+ * This is main.
  */
 public class Main
 {
     /**
-     * @param args bla
+     * The main.
+     *
+     * @param args great stuff.
      */
     public static void main(final String[] args)
     {

--- a/agrona/src/main/java/org/agrona/Main.java
+++ b/agrona/src/main/java/org/agrona/Main.java
@@ -21,6 +21,14 @@ package org.agrona;
 public class Main
 {
     /**
+     * We don't want instances.
+     */
+    private Main()
+    {
+
+    }
+
+    /**
      * The main.
      *
      * @param args great stuff.

--- a/agrona/src/main/java/org/agrona/Main.java
+++ b/agrona/src/main/java/org/agrona/Main.java
@@ -18,7 +18,7 @@ package org.agrona;
 /**
  * This is main.
  */
-public class Main
+public final class Main
 {
     /**
      * We don't want instances.

--- a/agrona/src/main/java/org/agrona/Main.java
+++ b/agrona/src/main/java/org/agrona/Main.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.agrona;
+
+/**
+ *
+ */
+public class Main
+{
+    /**
+     * @param args bla
+     */
+    public static void main(final String[] args)
+    {
+        final long offset = UnsafeApi.arrayBaseOffset(String[].class);
+        System.out.println("arrayBaseOffset:" + offset);
+    }
+}

--- a/agrona/src/main/java/org/agrona/UnsafeApi.java
+++ b/agrona/src/main/java/org/agrona/UnsafeApi.java
@@ -74,8 +74,9 @@ public final class UnsafeApi
      * See {@code jdk.internal.misc.Unsafe#arrayBaseOffset(java.lang.Class)}.
      * @param arg0 arg0
      * @return value
+     * @apiNote This method always returns a long regardless of the JDK version.
      */
-    public static int arrayBaseOffset(
+    public static long arrayBaseOffset(
         final Class<?> arg0)
     {
         throw new UnsupportedOperationException("'arrayBaseOffset' not implemented");

--- a/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
+++ b/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
@@ -49,11 +49,10 @@ public final class UnsafeApiBootstrap
         final String methodName,
         final MethodType methodType) throws Throwable
     {
-
         System.out.println("UnsafeApiBootstrap.bootstrapArrayBaseOffset");
 
         // Get Unsafe class from method type
-        final Class<?> unsafeClass = methodType.parameterType(1);
+        final Class<?> unsafeClass = methodType.parameterType(0);
 
         try
         {
@@ -69,13 +68,7 @@ public final class UnsafeApiBootstrap
                 System.out.println("arrayBaseOffset returns long");
 
                 // Method already returns long, use it directly
-                final MethodHandle adapter = MethodHandles.permuteArguments(
-                    targetMethod,
-                    methodType,  // (Class, Unsafe) -> long
-                    1, 0        // Permute arguments: Unsafe first, then Class
-                );
-
-                return new ConstantCallSite(adapter);
+                return new ConstantCallSite(targetMethod);
             }
             else
             {
@@ -91,14 +84,7 @@ public final class UnsafeApiBootstrap
                     longReturnType
                 );
 
-                // Permute arguments from (Unsafe, Class) to (Class, Unsafe)
-                final MethodHandle adapter = MethodHandles.permuteArguments(
-                    convertedMethod,
-                    methodType,  // (Class, Unsafe) -> long
-                    1, 0        // Permute arguments: Unsafe first, then Class
-                );
-
-                return new ConstantCallSite(adapter);
+                return new ConstantCallSite(convertedMethod);
             }
         }
         catch (final Exception e)

--- a/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
+++ b/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
@@ -25,6 +25,15 @@ import java.lang.reflect.Method;
  */
 public class UnsafeApiBootstrap
 {
+
+    /**
+     * We don't want instances.
+     */
+    private UnsafeApiBootstrap()
+    {
+
+    }
+
     /**
      * Bootstrap method for arrayBaseOffset that will be called by the JVM when
      * the invokedynamic instruction is executed for the first time.

--- a/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
+++ b/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
@@ -1,6 +1,5 @@
 /*
  * Copyright 2014-2025 Real Logic Limited.
- * Copyright 2012 The Netty Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
+++ b/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Method;
 /**
  * Great stuff.
  */
-public class UnsafeApiBootstrap
+public final class UnsafeApiBootstrap
 {
 
     /**

--- a/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
+++ b/agrona/src/main/java/org/agrona/UnsafeApiBootstrap.java
@@ -1,0 +1,67 @@
+package org.agrona;
+
+
+import java.lang.invoke.*;
+import java.lang.reflect.Method;
+
+/**
+ * todo
+ */
+public class UnsafeApiBootstrap
+{
+    /**
+     * Bootstrap method for arrayBaseOffset that will be called by the JVM when
+     * the invokedynamic instruction is executed for the first time.
+     *
+     * @param lookup      The lookup context
+     * @param methodName  The name of the method to find
+     * @param methodType  The method type (signature) expected at the call site
+     * @return            A CallSite bound to the appropriate implementation
+     * @throws Throwable  If method resolution fails
+     */
+    public static CallSite bootstrapArrayBaseOffset(
+        MethodHandles.Lookup lookup,
+        String methodName,
+        MethodType methodType) throws Throwable {
+
+        if (!methodName.equals("arrayBaseOffset") ||
+            !methodType.returnType().equals(long.class) ||
+            methodType.parameterCount() != 2) {
+            throw new IllegalArgumentException("Invalid method signature for arrayBaseOffset");
+        }
+
+        Class<?> unsafeClass = methodType.parameterType(1);
+
+        MethodHandle mh;
+        try {
+            Method longMethod = unsafeClass.getMethod("arrayBaseOffset", Class.class);
+            if (longMethod.getReturnType() == long.class) {
+                mh = lookup.unreflect(longMethod);
+                // Ensure method handle has the expected type
+                mh = mh.asType(methodType);
+                return new ConstantCallSite(mh);
+            }
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+        }
+
+        try {
+            Method intMethod = unsafeClass.getMethod("arrayBaseOffset", Class.class);
+            if (intMethod.getReturnType() == int.class) {
+                // We need to convert the int return value to long
+                mh = lookup.unreflect(intMethod);
+
+                MethodHandle filter = MethodHandles.explicitCastArguments(
+                    mh,
+                    mh.type().changeReturnType(long.class)
+                );
+
+                filter = filter.asType(methodType);
+                return new ConstantCallSite(filter);
+            }
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new RuntimeException("Could not find arrayBaseOffset method", e);
+        }
+
+        throw new RuntimeException("No suitable arrayBaseOffset method found");
+    }
+}

--- a/agrona/src/main/java/org/agrona/concurrent/AbstractConcurrentArrayQueue.java
+++ b/agrona/src/main/java/org/agrona/concurrent/AbstractConcurrentArrayQueue.java
@@ -113,7 +113,7 @@ public abstract class AbstractConcurrentArrayQueue<E>
     /**
      * Array base.
      */
-    protected static final int BUFFER_ARRAY_BASE;
+    protected static final long BUFFER_ARRAY_BASE;
     /**
      * Shift for scale.
      */

--- a/agrona/src/main/java/org/agrona/concurrent/ManyToManyConcurrentArrayQueue.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ManyToManyConcurrentArrayQueue.java
@@ -42,7 +42,7 @@ import java.util.function.Consumer;
 @SuppressWarnings("removal")
 public class ManyToManyConcurrentArrayQueue<E> extends AbstractConcurrentArrayQueue<E>
 {
-    private static final int SEQUENCES_ARRAY_BASE = UnsafeApi.arrayBaseOffset(long[].class);
+    private static final long SEQUENCES_ARRAY_BASE = UnsafeApi.arrayBaseOffset(long[].class);
 
     private final long[] sequences;
 

--- a/agrona/src/test/java/org/agrona/UnsafeApiTest.java
+++ b/agrona/src/test/java/org/agrona/UnsafeApiTest.java
@@ -102,7 +102,7 @@ class UnsafeApiTest
         Object[].class })
     void arrayBaseOffset(final Class<?> clazz)
     {
-        assertThat(UnsafeApi.arrayBaseOffset(clazz), greaterThan(0));
+        assertThat(UnsafeApi.arrayBaseOffset(clazz), greaterThan(0l));
     }
 
     @ParameterizedTest
@@ -224,7 +224,7 @@ class UnsafeApiTest
     void putLongUnaligned(final int offset)
     {
         final Object array = UnsafeApi.allocateUninitializedArray(byte.class, 32);
-        final int arrayBaseOffset = UnsafeApi.arrayBaseOffset(array.getClass());
+        final long arrayBaseOffset = UnsafeApi.arrayBaseOffset(array.getClass());
 
         final long value = ThreadLocalRandom.current().nextLong();
         UnsafeApi.putLongUnaligned(array, arrayBaseOffset + offset, value);

--- a/agrona/src/test/java/org/agrona/UnsafeApiTest.java
+++ b/agrona/src/test/java/org/agrona/UnsafeApiTest.java
@@ -102,7 +102,7 @@ class UnsafeApiTest
         Object[].class })
     void arrayBaseOffset(final Class<?> clazz)
     {
-        assertThat(UnsafeApi.arrayBaseOffset(clazz), greaterThan(0l));
+        assertThat(UnsafeApi.arrayBaseOffset(clazz), greaterThan(0L));
     }
 
     @ParameterizedTest

--- a/buildSrc/src/main/java/org/agrona/build/UnsafeApiBytecodeGenerator.java
+++ b/buildSrc/src/main/java/org/agrona/build/UnsafeApiBytecodeGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.agrona.build;
 
 import net.bytebuddy.build.Plugin;

--- a/buildSrc/src/main/java/org/agrona/build/UnsafeApiBytecodeGenerator.java
+++ b/buildSrc/src/main/java/org/agrona/build/UnsafeApiBytecodeGenerator.java
@@ -98,8 +98,6 @@ public final class UnsafeApiBytecodeGenerator implements Plugin
                     final @NotNull Context implementationContext,
                     final @NotNull MethodDescription instrumentedMethod)
                 {
-                    // First load the Class parameter (at index 0 for static methods)
-                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
 
                     // Load the UNSAFE static field
                     methodVisitor.visitFieldInsn(
@@ -108,7 +106,10 @@ public final class UnsafeApiBytecodeGenerator implements Plugin
                         "UNSAFE",
                         Type.getDescriptor(UNSAFE_CLASS));
 
-                    // Create a handle to the bootstrap method
+                    // First load the Class parameter (at index 0 for static methods)
+                    methodVisitor.visitVarInsn(Opcodes.ALOAD, 0);
+
+                        // Create a handle to the bootstrap method
                     Handle bootstrapHandle = new Handle(
                         Opcodes.H_INVOKESTATIC,
                         "org/agrona/UnsafeApiBootstrap",
@@ -118,9 +119,9 @@ public final class UnsafeApiBytecodeGenerator implements Plugin
 
                     // Generate the INVOKEDYNAMIC instruction
                     methodVisitor.visitInvokeDynamicInsn(
-                        "arrayBaseOffset",                        // Method name
-                        "(Ljava/lang/Class;Ljdk/internal/misc/Unsafe;)J", // Method descriptor
-                        bootstrapHandle                           // Bootstrap method handle
+                        "arrayBaseOffset",
+                        "(Ljdk/internal/misc/Unsafe;Ljava/lang/Class;)J",
+                        bootstrapHandle
                     );
 
                     // Return the long value

--- a/buildSrc/src/main/java/org/agrona/build/UnsafeApiSourceGenerator.java
+++ b/buildSrc/src/main/java/org/agrona/build/UnsafeApiSourceGenerator.java
@@ -90,7 +90,7 @@ public class UnsafeApiSourceGenerator extends DefaultTask
     /**
      * Generate {@code org.agrona.UnsafeApi} source file.
      */
-    @SuppressWarnings({"checkstyle:Regexp", "MethodLength"})
+    @SuppressWarnings({ "checkstyle:Regexp", "MethodLength" })
     @TaskAction
     public void run()
     {
@@ -222,8 +222,8 @@ public class UnsafeApiSourceGenerator extends DefaultTask
             Files.writeString(
                 outputDirectory.toPath().resolve("org/agrona/UnsafeApi.java"),
                 code
-                    .replace("$year", Integer.toString(LocalDate.now().getYear()))
-                    .replace("$body", buffer),
+                .replace("$year", Integer.toString(LocalDate.now().getYear()))
+                .replace("$body", buffer),
                 StandardCharsets.US_ASCII,
                 StandardOpenOption.WRITE,
                 StandardOpenOption.CREATE,

--- a/buildSrc/src/main/java/org/agrona/build/UnsafeApiSourceGenerator.java
+++ b/buildSrc/src/main/java/org/agrona/build/UnsafeApiSourceGenerator.java
@@ -90,7 +90,7 @@ public class UnsafeApiSourceGenerator extends DefaultTask
     /**
      * Generate {@code org.agrona.UnsafeApi} source file.
      */
-    @SuppressWarnings({ "checkstyle:Regexp", "MethodLength" })
+    @SuppressWarnings({"checkstyle:Regexp", "MethodLength"})
     @TaskAction
     public void run()
     {
@@ -176,11 +176,29 @@ public class UnsafeApiSourceGenerator extends DefaultTask
                     {
                         buffer.append("     * @return value").append(lineSeparator);
                     }
+
+                    // Add special note for arrayBaseOffset method
+                    if (method.getName().equals("arrayBaseOffset"))
+                    {
+                        buffer.append("     * @apiNote This method always returns a long regardless of the JDK version.")
+                            .append(lineSeparator);
+                    }
+
                     buffer.append("     */").append(lineSeparator);
 
-                    buffer.append("    public static ")
-                        .append(TYPE_NAME.get(method.getReturnType())).append(' ')
-                        .append(method.getName()).append("(");
+                    buffer.append("    public static ");
+
+                    // Check if this is the arrayBaseOffset method and force long return type
+                    if (method.getName().equals("arrayBaseOffset"))
+                    {
+                        buffer.append("long");
+                    }
+                    else
+                    {
+                        buffer.append(TYPE_NAME.get(method.getReturnType()));
+                    }
+
+                    buffer.append(' ').append(method.getName()).append("(");
 
                     for (int i = 0; i < parameters.length; i++)
                     {
@@ -204,8 +222,8 @@ public class UnsafeApiSourceGenerator extends DefaultTask
             Files.writeString(
                 outputDirectory.toPath().resolve("org/agrona/UnsafeApi.java"),
                 code
-                .replace("$year", Integer.toString(LocalDate.now().getYear()))
-                .replace("$body", buffer),
+                    .replace("$year", Integer.toString(LocalDate.now().getYear()))
+                    .replace("$body", buffer),
                 StandardCharsets.US_ASCII,
                 StandardOpenOption.WRITE,
                 StandardOpenOption.CREATE,


### PR DESCRIPTION
With JDK 25 the Unsafe function arrayBaseOffset changed the return type from int to long.

This PR fixed the UnsafeAPI so that at runtime it is determined which Unsafe method is available using INVOKE_DYNAMIC and then calls it.

This fix will break binary compatibility because the original UnsafeApi.arrayBaseOffset that returns an int will be replaced by one returning a long no matter which JDK version is used.