### PR TITLE
Fix an issue in IntHashSet's retainAll implementation that can lead to an infinite loop

### DIFF
--- a/agrona/src/main/java/org/agrona/collections/IntHashSet.java
+++ b/agrona/src/main/java/org/agrona/collections/IntHashSet.java
@@ -592,8 +592,14 @@ public class IntHashSet extends AbstractSet<Integer>
 
         if (removed && sizeOfArrayValues > 0)
         {
-            @DoNotSub final int newCapacity =
-                Math.max(DEFAULT_INITIAL_CAPACITY, findNextPositivePowerOfTwo(sizeOfArrayValues));
+            @DoNotSub int proposedCapacity = findNextPositivePowerOfTwo(sizeOfArrayValues);
+
+            if (proposedCapacity == sizeOfArrayValues)
+            {
+                proposedCapacity = findNextPositivePowerOfTwo(sizeOfArrayValues + 1);
+            }
+
+            @DoNotSub final int newCapacity = Math.max(DEFAULT_INITIAL_CAPACITY, proposedCapacity);
             rehash(newCapacity);
         }
 
@@ -630,8 +636,14 @@ public class IntHashSet extends AbstractSet<Integer>
 
         if (removed && sizeOfArrayValues > 0)
         {
-            @DoNotSub final int newCapacity =
-                Math.max(DEFAULT_INITIAL_CAPACITY, findNextPositivePowerOfTwo(sizeOfArrayValues));
+            @DoNotSub int proposedCapacity = findNextPositivePowerOfTwo(sizeOfArrayValues);
+
+            if (proposedCapacity == sizeOfArrayValues)
+            {
+                proposedCapacity = findNextPositivePowerOfTwo(sizeOfArrayValues + 1);
+            }
+
+            @DoNotSub final int newCapacity = Math.max(DEFAULT_INITIAL_CAPACITY, proposedCapacity);
             rehash(newCapacity);
         }
 

--- a/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
+++ b/agrona/src/test/java/org/agrona/collections/IntHashSetTest.java
@@ -15,6 +15,7 @@
  */
 package org.agrona.collections;
 
+import org.agrona.BitUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -1072,6 +1073,39 @@ class IntHashSetTest
         assertTrue(testSet.contains(42));
         assertTrue(testSet.contains(500));
         assertFalse(testSet.contains(MISSING_VALUE));
+    }
+
+    @Test
+    public void retainAllRemovesNonMissingValuesLeavingCollectionSizedAsPowerOfTwo()
+    {
+        testSet.addAll(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(BitUtil.findNextPositivePowerOfTwo(INITIAL_CAPACITY), testSet.capacity());
+
+        final IntHashSet coll = new IntHashSet();
+        coll.addAll(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8));
+
+        testSet.retainAll(coll);
+        assertEquals(8, testSet.size());
+
+        assertTrue(testSet.capacity() > testSet.size());
+        // testSet.contains(9) (or any value not in testSet) would loop forever, because
+        // testSet.capacity() has been reduced such that there is no space for a sentinel missing value.
+    }
+
+    @Test
+    public void retainAllWithCollectionRemovesNonMissingValuesLeavingCollectionSizedAsPowerOfTwo()
+    {
+        testSet.addAll(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+        assertEquals(BitUtil.findNextPositivePowerOfTwo(INITIAL_CAPACITY), testSet.capacity());
+
+        final List<Integer> coll = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8);
+
+        testSet.retainAll(coll);
+        assertEquals(8, testSet.size());
+
+        assertTrue(testSet.capacity() > testSet.size());
+        // testSet.contains(9) (or any value not in testSet) would loop forever, because
+        // testSet.capacity() has been reduced such that there is no space for a sentinel missing value.
     }
 
     @Test


### PR DESCRIPTION
The issue is that the backing array is corrupted in such a way that it no longer contains the sentinel missing value.

When doing a .contains check it goes into an infinite loop.

The corruption happens when we rehash to a capacity that is both a power of two and the same as the new size of the set. 

We encountered this issue in production when our application work loop hung. 

We believe this PR addresses the underlying issue. In the meantime we have a workaround that avoids calling retainAll.

Please let us know if you need anything more to accept this PR.