### PR TITLE
Fixes problem with gradle and bytebuddy baseline:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -306,6 +306,20 @@ project(':agrona') {
         }
     }
 
+    configurations.matching { it.name == "baseline" }.all {
+        resolutionStrategy {
+            componentSelection {
+                all {
+                    if (candidate.group == "org.agrona" &&
+                            candidate.module == "agrona" &&
+                            candidate.version =~ /-rc\d+$/) {
+                        reject("Ignore release candidates for baseline")
+                    }
+                }
+            }
+        }
+    }
+
     jar {
         from sourceSets.generated.output
 


### PR DESCRIPTION
The error:

Failed to resolve potential dependency for task 'baseline' of project 'agrona' on 'byteBuddy' of project 'agrona' - dependency must be declared manually if appropriate org.gradle.api.internal.tasks.TaskDependencyResolveException: Could not determine the dependencies of task ':agrona:baseline'.

The cause:
Both 2.3.0-rc1 and 2.3.0-SNAPSHOT match.

Fix:
the release candidates have been excluded from matches. No hard guarantees are given on rc anyway.