### PR TITLE
Weaken memory ordering OneToOnRingBuffer

### DIFF
--- a/agrona/src/main/java/org/agrona/concurrent/ringbuffer/OneToOneRingBuffer.java
+++ b/agrona/src/main/java/org/agrona/concurrent/ringbuffer/OneToOneRingBuffer.java
@@ -20,8 +20,6 @@ import org.agrona.concurrent.AtomicBuffer;
 import org.agrona.concurrent.ControlledMessageHandler;
 import org.agrona.concurrent.MessageHandler;
 
-import java.lang.invoke.VarHandle;
-
 import static java.lang.Math.max;
 import static org.agrona.BitUtil.align;
 import static org.agrona.concurrent.ControlledMessageHandler.Action.*;
@@ -100,8 +98,7 @@ public final class OneToOneRingBuffer implements RingBuffer
             return false;
         }
 
-        buffer.putIntRelease(lengthOffset(recordIndex), -recordLength);
-        VarHandle.releaseFence();
+        buffer.putIntOpaque(lengthOffset(recordIndex), -recordLength);
 
         buffer.putBytes(encodedMsgOffset(recordIndex), srcBuffer, offset, length);
         buffer.putInt(typeOffset(recordIndex), msgTypeId);
@@ -127,8 +124,7 @@ public final class OneToOneRingBuffer implements RingBuffer
             return recordIndex;
         }
 
-        buffer.putIntRelease(lengthOffset(recordIndex), -recordLength);
-        VarHandle.releaseFence();
+        buffer.putIntOpaque(lengthOffset(recordIndex), -recordLength);
         buffer.putInt(typeOffset(recordIndex), msgTypeId);
 
         return encodedMsgOffset(recordIndex);
@@ -472,9 +468,6 @@ public final class OneToOneRingBuffer implements RingBuffer
         if (0 != padding)
         {
             buffer.putLong(0, 0L);
-            buffer.putIntRelease(lengthOffset(recordIndex), -padding);
-            VarHandle.releaseFence();
-
             buffer.putInt(typeOffset(recordIndex), PADDING_MSG_TYPE_ID);
             buffer.putIntRelease(lengthOffset(recordIndex), padding);
         }

--- a/agrona/src/test/java/org/agrona/concurrent/ringbuffer/OneToOneRingBufferTest.java
+++ b/agrona/src/test/java/org/agrona/concurrent/ringbuffer/OneToOneRingBufferTest.java
@@ -109,7 +109,6 @@ class OneToOneRingBufferTest
         final InOrder inOrder = inOrder(buffer);
         inOrder.verify(buffer).putLongRelease(TAIL_COUNTER_INDEX, tail + alignedRecordLength);
         inOrder.verify(buffer).putLong((int)tail + alignedRecordLength, 0L);
-        inOrder.verify(buffer).putIntRelease(lengthOffset((int)tail), -recordLength);
         inOrder.verify(buffer).putBytes(encodedMsgOffset((int)tail), srcBuffer, srcIndex, length);
         inOrder.verify(buffer).putInt(typeOffset((int)tail), MSG_TYPE_ID);
         inOrder.verify(buffer).putIntRelease(lengthOffset((int)tail), recordLength);
@@ -175,13 +174,11 @@ class OneToOneRingBufferTest
         inOrder.verify(buffer).putLongRelease(TAIL_COUNTER_INDEX, tail + alignedRecordLength + HEADER_LENGTH);
 
         inOrder.verify(buffer).putLong(0, 0L);
-        inOrder.verify(buffer).putIntRelease(lengthOffset((int)tail), -HEADER_LENGTH);
         inOrder.verify(buffer).putInt(typeOffset((int)tail), PADDING_MSG_TYPE_ID);
         inOrder.verify(buffer).putIntRelease(lengthOffset((int)tail), HEADER_LENGTH);
 
         inOrder.verify(buffer).putLong(alignedRecordLength, 0L);
 
-        inOrder.verify(buffer).putIntRelease(lengthOffset(0), -recordLength);
         inOrder.verify(buffer).putBytes(encodedMsgOffset(0), srcBuffer, srcIndex, length);
         inOrder.verify(buffer).putInt(typeOffset(0), MSG_TYPE_ID);
         inOrder.verify(buffer).putIntRelease(lengthOffset(0), recordLength);
@@ -208,13 +205,11 @@ class OneToOneRingBufferTest
         inOrder.verify(buffer).putLongRelease(TAIL_COUNTER_INDEX, tail + alignedRecordLength + HEADER_LENGTH);
 
         inOrder.verify(buffer).putLong(0, 0L);
-        inOrder.verify(buffer).putIntRelease(lengthOffset((int)tail), -HEADER_LENGTH);
         inOrder.verify(buffer).putInt(typeOffset((int)tail), PADDING_MSG_TYPE_ID);
         inOrder.verify(buffer).putIntRelease(lengthOffset((int)tail), HEADER_LENGTH);
 
         inOrder.verify(buffer).putLong(alignedRecordLength, 0L);
 
-        inOrder.verify(buffer).putIntRelease(lengthOffset(0), -recordLength);
         inOrder.verify(buffer).putBytes(encodedMsgOffset(0), srcBuffer, srcIndex, length);
         inOrder.verify(buffer).putInt(typeOffset(0), MSG_TYPE_ID);
         inOrder.verify(buffer).putIntRelease(lengthOffset(0), recordLength);
@@ -437,7 +432,7 @@ class OneToOneRingBufferTest
         final InOrder inOrder = inOrder(buffer);
         inOrder.verify(buffer).putLongRelease(TAIL_COUNTER_INDEX, alignedRecordLength);
         inOrder.verify(buffer).putLong(alignedRecordLength, 0L);
-        inOrder.verify(buffer).putIntRelease(lengthOffset(0), -recordLength);
+        inOrder.verify(buffer).putIntOpaque(lengthOffset(0), -recordLength);
         inOrder.verify(buffer).putInt(typeOffset(0), msgTypeId);
     }
 
@@ -481,7 +476,6 @@ class OneToOneRingBufferTest
         inOrder.verify(buffer).putLongRelease(TAIL_COUNTER_INDEX, CAPACITY * 2L);
         final int paddingIndex = CAPACITY - 10;
         inOrder.verify(buffer).putLong(0, 0L);
-        inOrder.verify(buffer).putIntRelease(lengthOffset(paddingIndex), -10);
         inOrder.verify(buffer).putInt(typeOffset(paddingIndex), PADDING_MSG_TYPE_ID);
         inOrder.verify(buffer).putIntRelease(lengthOffset(paddingIndex), 10);
         inOrder.verifyNoMoreInteractions();


### PR DESCRIPTION
The current code has excessive memory ordering and it can be reduced. 