### PR TITLE
Reject non-ASCII digit look-alikes in AsciiEncoding SWAR fast paths

### DIFF
--- a/agrona/src/main/java/org/agrona/AsciiEncoding.java
+++ b/agrona/src/main/java/org/agrona/AsciiEncoding.java
@@ -595,21 +595,37 @@ public final class AsciiEncoding
 
     private static int readFourBytesLittleEndian(final CharSequence cs, final int index)
     {
-        return cs.charAt(index + 3) << 24 |
-            cs.charAt(index + 2) << 16 |
-            cs.charAt(index + 1) << 8 |
-            cs.charAt(index);
+        final int c0 = cs.charAt(index);
+        final int c1 = cs.charAt(index + 1);
+        final int c2 = cs.charAt(index + 2);
+        final int c3 = cs.charAt(index + 3);
+        // A char above 0xFF is not ASCII; its high byte would otherwise be shifted
+        // out of the packed word (leaving a digit look-alike), so force the digit
+        // check to fail here instead.
+        final int nonAscii = ((c0 | c1 | c2 | c3) & 0xFF00) != 0 ? 0xFFFFFFFF : 0;
+        return nonAscii | c3 << 24 | c2 << 16 | c1 << 8 | c0;
     }
 
     private static long readEightBytesLittleEndian(final CharSequence cs, final int index)
     {
-        return (long)cs.charAt(index + 7) << 56 |
-            (long)cs.charAt(index + 6) << 48 |
-            (long)cs.charAt(index + 5) << 40 |
-            (long)cs.charAt(index + 4) << 32 |
-            (long)cs.charAt(index + 3) << 24 |
-            (long)cs.charAt(index + 2) << 16 |
-            cs.charAt(index + 1) << 8 |
-            cs.charAt(index);
+        final int c0 = cs.charAt(index);
+        final int c1 = cs.charAt(index + 1);
+        final int c2 = cs.charAt(index + 2);
+        final int c3 = cs.charAt(index + 3);
+        final int c4 = cs.charAt(index + 4);
+        final int c5 = cs.charAt(index + 5);
+        final int c6 = cs.charAt(index + 6);
+        final int c7 = cs.charAt(index + 7);
+        // See readFourBytesLittleEndian: reject a non-ASCII char whose high byte
+        // would be shifted out of the packed word.
+        final long nonAscii = ((c0 | c1 | c2 | c3 | c4 | c5 | c6 | c7) & 0xFF00) != 0 ? -1L : 0L;
+        return nonAscii | (long)c7 << 56 |
+            (long)c6 << 48 |
+            (long)c5 << 40 |
+            (long)c4 << 32 |
+            (long)c3 << 24 |
+            (long)c2 << 16 |
+            c1 << 8 |
+            c0;
     }
 }

--- a/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
+++ b/agrona/src/test/java/org/agrona/AsciiEncodingTest.java
@@ -116,6 +116,11 @@ class AsciiEncodingTest
         assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("123456789İ", 0, 10));
         assertThrows(
             AsciiNumberFormatException.class, () -> parseLongAscii("123456789012345678İ", 0, 19));
+
+        // A look-alike in the top lane of a 4-/8-char SWAR window: its high byte
+        // shifts out of the word, leaving only the digit-looking low byte.
+        assertThrows(AsciiNumberFormatException.class, () -> parseIntAscii("123İ", 0, 4));
+        assertThrows(AsciiNumberFormatException.class, () -> parseLongAscii("1234567İ", 0, 8));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #366. That PR fixed the scalar tail loops of the `CharSequence` integer parsers but noted the SIMD (SWAR) fast paths were unaffected — this closes that gap.

`readFourBytesLittleEndian`/`readEightBytesLittleEndian` pack each `char` into a byte lane with a left shift. A non-ASCII char in the **top** lane (e.g. `İ` = U+0130, low byte `0x30`) has its high byte shifted out of the 32-/64-bit word, so only the digit-looking low byte survives and `isFourDigitsAsciiEncodedNumber` accepts it:

```java
AsciiEncoding.parseIntAscii("123İ", 0, 4);      // returned 1230 instead of throwing
AsciiEncoding.parseLongAscii("1234567İ", 0, 8); // returned 12345670 instead of throwing
```

(A look-alike in a non-top lane already corrupts an adjacent byte and is correctly rejected — only the top lane leaks.)

Fix: OR the chars in each reader and, if any exceeds `0xFF`, force the digit check to fail. This reuses the chars already loaded, so there are no extra reads on the fast path. Extended `shouldRejectNonAsciiCharsWhoseLowByteLooksLikeADigit` with top-lane cases for the 4- and 8-char windows (they fail before this change, pass after).